### PR TITLE
Renaming CompletedDate on CompletedItem for v9 migration

### DIFF
--- a/src/Todoist.Net/Models/CompletedItem.cs
+++ b/src/Todoist.Net/Models/CompletedItem.cs
@@ -16,8 +16,8 @@ namespace Todoist.Net.Models
         /// <value>
         /// The completed date.
         /// </value>
-        [JsonProperty("completed_date")]
-        public DateTime CompletedDate { get; internal set; }
+        [JsonProperty("completed_at")]
+        public DateTime CompletedAt { get; internal set; }
 
         /// <summary>
         /// Gets the content.


### PR DESCRIPTION
You missed this property rename during your v9 migration.

I really wish they had just made completed items just normal item objects on there api lol