### PR TITLE
Add support for returning sync token values after committing transactions.

### DIFF
--- a/src/Todoist.Net.Tests/Services/TransactionTests.cs
+++ b/src/Todoist.Net.Tests/Services/TransactionTests.cs
@@ -30,11 +30,12 @@ namespace Todoist.Net.Tests.Services
             var note = new Note("Demo note");
             transaction.Notes.AddToProjectAsync(note, projectId).Wait();
 
-            transaction.CommitAsync().Wait();
+            var syncToken = transaction.CommitAsync().Result;
 
             var projectInfo = client.Projects.GetAsync(project.Id).Result;
 
             Assert.True(projectInfo.Notes.Count > 0);
+            Assert.NotNull(syncToken);
 
             var deleteTransaction = client.CreateTransaction();
 

--- a/src/Todoist.Net/IAdvancedTodoistClient.cs
+++ b/src/Todoist.Net/IAdvancedTodoistClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -12,11 +12,14 @@ namespace Todoist.Net
         /// Executes the commands asynchronous.
         /// </summary>
         /// <param name="commands">The commands.</param>
-        /// <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.The task object representing the asynchronous operation.</returns>
+        /// <returns>
+        /// Returns <see cref="Task{TResult}" />. The task object representing the asynchronous operation
+        /// that at completion returns the commands execution sync_token.
+        /// </returns>
         /// <exception cref="System.ArgumentNullException">Value cannot be null - commands.</exception>
         /// <exception cref="System.AggregateException">Command execution exception.</exception>
         /// <exception cref="HttpRequestException">API exception.</exception>
-        Task ExecuteCommandsAsync(params Command[] commands);
+        Task<string> ExecuteCommandsAsync(params Command[] commands);
 
         /// <summary>
         /// Posts the request asynchronous.

--- a/src/Todoist.Net/Models/SyncResponse.cs
+++ b/src/Todoist.Net/Models/SyncResponse.cs
@@ -12,5 +12,8 @@ namespace Todoist.Net.Models
 
         [JsonProperty("temp_id_mapping")]
         public Dictionary<Guid, string> TempIdMappings { get; set; }
+
+        [JsonProperty("sync_token")]
+        public string SyncToken { get; set; }
     }
 }

--- a/src/Todoist.Net/Services/ITransaction.cs
+++ b/src/Todoist.Net/Services/ITransaction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -70,9 +70,12 @@ namespace Todoist.Net.Services
         /// <summary>
         /// Commits the transaction asynchronous.
         /// </summary>
-        /// <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.The task object representing the asynchronous operation.</returns>
+        /// <returns>
+        /// Returns <see cref="Task{TResult}" />. The task object representing the asynchronous operation
+        /// that at completion returns the transaction sync_token.
+        /// </returns>
         /// <exception cref="AggregateException">Command execution exception.</exception>
         /// <exception cref="HttpRequestException">API exception.</exception>
-        Task CommitAsync();
+        Task<string> CommitAsync();
     }
 }

--- a/src/Todoist.Net/Services/Transaction.cs
+++ b/src/Todoist.Net/Services/Transaction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -59,14 +59,17 @@ namespace Todoist.Net.Services
         /// <summary>
         /// Commits the transaction asynchronous.
         /// </summary>
-        /// <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.The task object representing the asynchronous operation.</returns>
+        /// <returns>
+        /// Returns <see cref="Task{TResult}" />. The task object representing the asynchronous operation
+        /// that at completion returns the transaction sync_token.
+        /// </returns>
         /// <exception cref="AggregateException">Command execution exception.</exception>
         /// <exception cref="HttpRequestException">API exception.</exception>
-        public async Task CommitAsync()
+        public async Task<string> CommitAsync()
         {
             try
             {
-                await _todoistClient.ExecuteCommandsAsync(_commands.ToArray()).ConfigureAwait(false);
+                return await _todoistClient.ExecuteCommandsAsync(_commands.ToArray()).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Todoist.Net/TodoistClient.cs
+++ b/src/Todoist.Net/TodoistClient.cs
@@ -262,12 +262,15 @@ namespace Todoist.Net
         /// Executes the commands asynchronous.
         /// </summary>
         /// <param name="commands">The commands.</param>
-        /// <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.The task object representing the asynchronous operation.</returns>
+        /// <returns>
+        /// Returns <see cref="Task{TResult}" />. The task object representing the asynchronous operation
+        /// that at completion returns the commands execution sync_token.
+        /// </returns>
         /// <exception cref="System.ArgumentNullException">Value cannot be null - commands.</exception>
         /// <exception cref="System.AggregateException">Command execution exception.</exception>
         /// <exception cref="ArgumentException">Value cannot be an empty collection.</exception>
         /// <exception cref="HttpRequestException">API exception.</exception>
-        async Task IAdvancedTodoistClient.ExecuteCommandsAsync(params Command[] commands)
+        async Task<string> IAdvancedTodoistClient.ExecuteCommandsAsync(params Command[] commands)
         {
             if (commands == null)
             {
@@ -294,6 +297,7 @@ namespace Todoist.Net
             {
                 UpdateTempIds(commands, syncResponse.TempIdMappings);
             }
+            return syncResponse.SyncToken;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #29

Changes include:

- Update the [`SyncResponse`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Models/SyncResponse.cs) model with a new property `SyncToken` that maps to `sync_token` Json property on the transaction response.
-  Update the [`IAdvancedTodoistClient.ExecuteCommandsAsync`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/IAdvancedTodoistClient.cs#L19) and its implementation in [`TodoistClient`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/TodoistClient.cs#L270) to return `Task<string>` containing the `sync_token` included in the response instead of plain `Task`.
- Update the [`ITransaction.CommitAsync()`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Services/ITransaction.cs#L76) and its implementation in [`Transaction`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Services/Transaction.cs#L65) to return `Task<string>` following the change made in `IAdvancedTodoistClient.ExecuteCommandsAsync`.
- Add assertion in `TransactionTests.CreateProjectAndCreateNote_Success()` test method to check the `sync_token` value returned by the `ITransaction.CommitAsync()` method.

