### PR TITLE
Add duration property to the Item model to support the new duration feature.

### DIFF
--- a/src/Todoist.Net.Tests/Models/DurationTests.cs
+++ b/src/Todoist.Net.Tests/Models/DurationTests.cs
@@ -1,0 +1,54 @@
+using System;
+
+using Todoist.Net.Models;
+using Todoist.Net.Tests.Extensions;
+using Xunit;
+
+namespace Todoist.Net.Tests.Models
+{
+    [Trait(Constants.TraitName, Constants.UnitTraitValue)]
+    public class DurationTests
+    {
+        [Fact]
+        public void AmountAssignment_InvalidValue_ThrowsException()
+        {
+            Duration duration;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                duration = new Duration(0, DurationUnit.Minute));
+
+            duration = new Duration(15, DurationUnit.Minute);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                duration.Amount = -5);
+        }
+
+        [Fact]
+        public void UnitAssignment_InvalidValue_ThrowsException()
+        {
+            Duration duration;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                duration = new Duration(15, null));
+
+            duration = new Duration(15, DurationUnit.Minute);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                duration.Unit = null);
+        }
+
+        [Fact]
+        public void TimeValueEvaluation_Success()
+        {
+            var duration = new Duration(15, DurationUnit.Minute);
+
+            Assert.Equal(TimeSpan.FromMinutes(15), duration.TimeValue);
+
+            duration.Amount = 3;
+            duration.Unit = DurationUnit.Day;
+
+            Assert.Equal(TimeSpan.FromDays(3), duration.TimeValue);
+        }
+
+    }
+}

--- a/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
+++ b/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
@@ -197,5 +197,37 @@ namespace Todoist.Net.Tests.Services
 
             client.Items.DeleteAsync(item.Id).Wait();
         }
+
+
+        [Fact]
+        [Trait(Constants.TraitName, Constants.IntegrationPremiumTraitValue)]
+        public void CreateItemClearDurationAndDelete_Success()
+        {
+            var client = TodoistClientFactory.Create(_outputHelper);
+
+            var item = new Item("duration task")
+            {
+                DueDate = new DueDate("22 Dec 2021 at 9:15", language: Language.English),
+                Duration = new Duration(45, DurationUnit.Minute)
+            };
+            client.Items.AddAsync(item).Wait();
+
+            var itemInfo = client.Items.GetAsync(item.Id).Result;
+
+            Assert.True(itemInfo.Item.Content == item.Content);
+            Assert.Equal("2021-12-22T09:15:00", itemInfo.Item.DueDate.StringDate);
+
+            Assert.Equal(item.Duration.Amount, itemInfo.Item.Duration.Amount);
+            Assert.Equal(item.Duration.Unit, itemInfo.Item.Duration.Unit);
+
+            itemInfo.Item.Duration = null;
+            client.Items.UpdateAsync(itemInfo.Item).Wait();
+
+            itemInfo = client.Items.GetAsync(item.Id).Result;
+            Assert.Null(itemInfo.Item.Duration);
+
+            client.Items.DeleteAsync(item.Id).Wait();
+        }
+
     }
 }

--- a/src/Todoist.Net/Models/Duration.cs
+++ b/src/Todoist.Net/Models/Duration.cs
@@ -64,15 +64,15 @@ namespace Todoist.Net.Models
         {
             get
             {
-                if (Unit == DurationUnit.Minute)
+                switch (Unit)
                 {
-                    return TimeSpan.FromMinutes(Amount);
+                    case var _ when Unit == DurationUnit.Minute:
+                        return TimeSpan.FromMinutes(Amount);
+                    case var _ when Unit == DurationUnit.Day:
+                        return TimeSpan.FromDays(Amount);
+                    default:
+                        throw new NotImplementedException();
                 }
-                if (Unit == DurationUnit.Day)
-                {
-                    return TimeSpan.FromDays(Amount);
-                }
-                throw new NotImplementedException();
             }
         }
 

--- a/src/Todoist.Net/Models/Duration.cs
+++ b/src/Todoist.Net/Models/Duration.cs
@@ -10,6 +10,9 @@ namespace Todoist.Net.Models
     public class Duration
     {
 
+        private int _amount;
+        private DurationUnit _unit;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Duration" /> class.
         /// </summary>
@@ -17,11 +20,8 @@ namespace Todoist.Net.Models
         /// <param name="unit">The time unit.</param>
         public Duration(int amount, DurationUnit unit)
         {
-            Amount = amount > 0
-                ? amount
-                : throw new ArgumentOutOfRangeException(nameof(amount), "Parameter must be greater than zero.");
-            Unit = unit
-                ?? throw new ArgumentNullException(nameof(unit));
+            Amount = amount;
+            Unit = unit;
         }
 
         internal Duration()
@@ -37,8 +37,15 @@ namespace Todoist.Net.Models
         /// <value>
         /// The time amount.
         /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">Duration amount must be greater than zero.</exception>"
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int Amount
+        {
+            get => _amount;
+            set => _amount = value > 0
+                ? value
+                : throw new ArgumentOutOfRangeException(nameof(Amount), "Duration amount must be greater than zero.");
+        }
 
         /// <summary>
         /// Gets or sets the duration time unit.
@@ -49,8 +56,13 @@ namespace Todoist.Net.Models
         /// <value>
         /// The duration unit.
         /// </value>
+        /// <exception cref="ArgumentNullException">Unit</exception>
         [JsonProperty("unit")]
-        public DurationUnit Unit { get; set; }
+        public DurationUnit Unit
+        {
+            get => _unit;
+            set => _unit = value ?? throw new ArgumentNullException(nameof(Unit));
+        }
 
 
         /// <summary>

--- a/src/Todoist.Net/Models/Duration.cs
+++ b/src/Todoist.Net/Models/Duration.cs
@@ -60,11 +60,21 @@ namespace Todoist.Net.Models
         /// The <see cref="TimeSpan"/> value of the duration.
         /// </value>
         [JsonIgnore]
-        public TimeSpan TimeValue => Unit == DurationUnit.Minute
-            ? TimeSpan.FromMinutes(Amount)
-            : Unit == DurationUnit.Day
-            ? TimeSpan.FromDays(Amount)
-            : throw new NotImplementedException();
+        public TimeSpan TimeValue
+        {
+            get
+            {
+                if (Unit == DurationUnit.Minute)
+                {
+                    return TimeSpan.FromMinutes(Amount);
+                }
+                if (Unit == DurationUnit.Day)
+                {
+                    return TimeSpan.FromDays(Amount);
+                }
+                throw new NotImplementedException();
+            }
+        }
 
     }
 }

--- a/src/Todoist.Net/Models/Duration.cs
+++ b/src/Todoist.Net/Models/Duration.cs
@@ -1,0 +1,70 @@
+using System;
+
+using Newtonsoft.Json;
+
+namespace Todoist.Net.Models
+{
+    /// <summary>
+    /// Represents durations for tasks.
+    /// </summary>
+    public class Duration
+    {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Duration" /> class.
+        /// </summary>
+        /// <param name="amount">The time amount.</param>
+        /// <param name="unit">The time unit.</param>
+        public Duration(int amount, DurationUnit unit)
+        {
+            Amount = amount > 0
+                ? amount
+                : throw new ArgumentOutOfRangeException(nameof(amount), "Parameter must be greater than zero.");
+            Unit = unit
+                ?? throw new ArgumentNullException(nameof(unit));
+        }
+
+        internal Duration()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the duration time amount.
+        /// </summary>
+        /// <remarks>
+        /// Must be a positive integer (greater than zero).
+        /// </remarks>
+        /// <value>
+        /// The time amount.
+        /// </value>
+        [JsonProperty("amount")]
+        public int Amount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration time unit.
+        /// </summary>
+        /// <remarks>
+        /// Either <c>minute</c> or <c>day</c>.
+        /// </remarks>
+        /// <value>
+        /// The duration unit.
+        /// </value>
+        [JsonProperty("unit")]
+        public DurationUnit Unit { get; set; }
+
+
+        /// <summary>
+        /// Gets the value of the duration as a <see cref="TimeSpan"/> object.
+        /// </summary>
+        /// <value>
+        /// The <see cref="TimeSpan"/> value of the duration.
+        /// </value>
+        [JsonIgnore]
+        public TimeSpan TimeValue => Unit == DurationUnit.Minute
+            ? TimeSpan.FromMinutes(Amount)
+            : Unit == DurationUnit.Day
+            ? TimeSpan.FromDays(Amount)
+            : throw new NotImplementedException();
+
+    }
+}

--- a/src/Todoist.Net/Models/DurationUnit.cs
+++ b/src/Todoist.Net/Models/DurationUnit.cs
@@ -1,0 +1,31 @@
+namespace Todoist.Net.Models
+{
+    /// <summary>
+    /// Represents a duration unit.
+    /// </summary>
+    /// <seealso cref="Todoist.Net.Models.StringEnum" />
+    public class DurationUnit : StringEnum
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationUnit" /> class.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        private DurationUnit(string value)
+            : base(value)
+        {
+        }
+
+        /// <summary>
+        /// Gets the minute unit.
+        /// </summary>
+        /// <value>The minute unit.</value>
+        public static DurationUnit Minute { get; } = new DurationUnit("minute");
+
+        /// <summary>
+        /// Gets the day unit.
+        /// </summary>
+        /// <value>The day unit.</value>
+        public static DurationUnit Day { get; } = new DurationUnit("day");
+
+    }
+}

--- a/src/Todoist.Net/Models/Item.cs
+++ b/src/Todoist.Net/Models/Item.cs
@@ -104,6 +104,18 @@ namespace Todoist.Net.Models
         public DueDate DueDate { get; set; }
 
         /// <summary>
+        /// Gets or sets the duration.
+        /// </summary>
+        /// <remarks>
+        /// Durations are only available for Todoist Premium users.
+        /// </remarks>
+        /// <value>
+        /// The duration.
+        /// </value>
+        [JsonProperty("duration")]
+        public Duration Duration { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether this instance is checked.
         /// </summary>
         /// <value><c>null</c> if [is checked] contains no value, <c>true</c> if [is checked]; otherwise, <c>false</c>.</value>

--- a/src/Todoist.Net/Models/Item.cs
+++ b/src/Todoist.Net/Models/Item.cs
@@ -112,7 +112,7 @@ namespace Todoist.Net.Models
         /// <value>
         /// The duration.
         /// </value>
-        [JsonProperty("duration")]
+        [JsonProperty("duration", NullValueHandling = NullValueHandling.Include)]
         public Duration Duration { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes #34

Changes include:

- Adding a [`Duration`](https://github.com/AhmedZaki99/todoist-net/blob/patch-3/src/Todoist.Net/Models/Duration.cs) model to be mapped against the task duration JSON object.
- Adding a [`DurationUnit`](https://github.com/AhmedZaki99/todoist-net/blob/patch-3/src/Todoist.Net/Models/DurationUnit.cs) model that extends [`StringEnum`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Models/StringEnum.cs) and supports two values: minute & day.
- Adding a [`Duration`](https://github.com/AhmedZaki99/todoist-net/blob/patch-3/src/Todoist.Net/Models/Item.cs#L116) property of type `Duration` in the [`Item`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Models/Item.cs) model.