### PR TITLE
Fix DueDate.StringDate conversion to and from DateTime.

### DIFF
--- a/src/Todoist.Net.Tests/Helpers/FakeLocalTimeZone.cs
+++ b/src/Todoist.Net.Tests/Helpers/FakeLocalTimeZone.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+
+namespace Todoist.Net.Tests.Helpers;
+
+/// <summary>
+/// A helper class that changes the local timezone to a fake timezone provided
+/// at initialization, and resets the original local timezone when disposed.
+/// </summary>
+/// <remarks>
+/// See this <see href="https://stackoverflow.com/questions/44413407/mock-the-country-timezone-you-are-running-unit-test-from">SO question</see> for more details.
+/// </remarks>
+public sealed class FakeLocalTimeZone : IDisposable
+{
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeLocalTimeZone"/> class
+    /// and changes the local time zone to the given <paramref name="fakeTimeZoneInfo"/>
+    /// until it's disposed.
+    /// </summary>
+    /// <param name="fakeTimeZoneInfo">The time zone to set as local until disposal.</param>
+    public FakeLocalTimeZone(TimeZoneInfo fakeTimeZoneInfo)
+    {
+        var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
+        var cachedData = info.GetValue(null);
+
+        var field = cachedData.GetType().GetField("_localTimeZone",
+            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Instance);
+
+        field.SetValue(cachedData, fakeTimeZoneInfo);
+    }
+
+    public void Dispose()
+    {
+        TimeZoneInfo.ClearCachedData();
+    }
+}

--- a/src/Todoist.Net.Tests/Helpers/FakeLocalTimeZoneTests.cs
+++ b/src/Todoist.Net.Tests/Helpers/FakeLocalTimeZoneTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+
+using Todoist.Net.Tests.Extensions;
+
+using Xunit;
+
+namespace Todoist.Net.Tests.Helpers;
+
+[Trait(Constants.TraitName, Constants.UnitTraitValue)]
+public class FakeLocalTimeZoneTests
+{
+
+    [Fact]
+    public void FakeLocalTimeZone_ShouldChangeLocalTimeZoneWithinScope_AndResetItBackOutsideScope()
+    {
+        var actualTimeZoneInfo = TimeZoneInfo.Local;
+
+        var timeZoneCollection = TimeZoneInfo
+            .GetSystemTimeZones()
+            .Where(t => !actualTimeZoneInfo.Equals(t))
+            .ToArray();
+
+        var randomIndex = new Random().Next(timeZoneCollection.Length);
+        var fakeTimeZoneInfo = timeZoneCollection.ElementAt(randomIndex);
+
+
+        Assert.NotEqual(fakeTimeZoneInfo, actualTimeZoneInfo);
+
+        using (var fakeLocalTimeZone = new FakeLocalTimeZone(fakeTimeZoneInfo))
+        {
+            Assert.Equal(fakeTimeZoneInfo, TimeZoneInfo.Local);
+        }
+        Assert.Equal(actualTimeZoneInfo, TimeZoneInfo.Local);
+    }
+
+}

--- a/src/Todoist.Net.Tests/Models/DueDateTests.cs
+++ b/src/Todoist.Net.Tests/Models/DueDateTests.cs
@@ -45,7 +45,7 @@ namespace Todoist.Net.Tests.Models
         [Fact]
         public void DateTimeAssignment_FloatingDueDateEvent_Success()
         {
-            var date = new DateTime(2018, 2, 5, 0, 0, 0, DateTimeKind.Utc);
+            var date = new DateTime(2018, 2, 5, 0, 0, 0, DateTimeKind.Unspecified);
 
             var dueDate = new DueDate(date);
 

--- a/src/Todoist.Net.Tests/Models/DueDateTests.cs
+++ b/src/Todoist.Net.Tests/Models/DueDateTests.cs
@@ -63,5 +63,54 @@ namespace Todoist.Net.Tests.Models
             Assert.Equal("2018-02-05T00:00:00Z", dueDate.StringDate);
             Assert.False(dueDate.IsFullDay);
         }
+
+
+        [Fact]
+        public void StringDateProperty_ShouldReturnExactAssignedValue_WhenValueIsFullDayDate()
+        {
+            // Arrange
+            var dueDate = new DueDate();
+            string initialValue = "2016-12-01";
+
+            // Act
+            dueDate.StringDate = initialValue; // Set initial value.
+            string returnedValue = dueDate.StringDate; // Get.
+            dueDate.StringDate = returnedValue; // Set returned value.
+
+            // Assert
+            Assert.Equal(returnedValue, dueDate.StringDate);
+        }
+
+        [Fact]
+        public void StringDateProperty_ShouldReturnExactAssignedValue_WhenValueIsFloatingDate()
+        {
+            // Arrange
+            var dueDate = new DueDate();
+            string initialValue = "2016-12-03T12:00:00";
+
+            // Act
+            dueDate.StringDate = initialValue; // Set initial value.
+            string returnedValue = dueDate.StringDate; // Get.
+            dueDate.StringDate = returnedValue; // Set returned value.
+
+            // Assert
+            Assert.Equal(returnedValue, dueDate.StringDate);
+        }
+
+        [Fact]
+        public void StringDateProperty_ShouldReturnExactAssignedValue_WhenValueIsFixedDate()
+        {
+            // Arrange
+            var dueDate = new DueDate();
+            string initialValue = "2016-12-06T13:00:00Z";
+
+            // Act
+            dueDate.StringDate = initialValue; // Set initial value.
+            string returnedValue = dueDate.StringDate; // Get.
+            dueDate.StringDate = returnedValue; // Set returned value.
+
+            // Assert
+            Assert.Equal(returnedValue, dueDate.StringDate);
+        }
     }
 }

--- a/src/Todoist.Net.Tests/Models/DueDateTests.cs
+++ b/src/Todoist.Net.Tests/Models/DueDateTests.cs
@@ -2,13 +2,35 @@ using System;
 
 using Todoist.Net.Models;
 using Todoist.Net.Tests.Extensions;
+using Todoist.Net.Tests.Helpers;
+
 using Xunit;
 
 namespace Todoist.Net.Tests.Models
 {
     [Trait(Constants.TraitName, Constants.UnitTraitValue)]
-    public class DueDateTests
+    public class DueDateTests : IDisposable
     {
+
+        private readonly FakeLocalTimeZone _fakeLocalTimeZone;
+
+        public DueDateTests()
+        {
+            var timeZoneCollection = System.TimeZoneInfo.GetSystemTimeZones();
+
+            var randomIndex = new Random().Next(timeZoneCollection.Count);
+            var fakeTimeZoneInfo = timeZoneCollection[randomIndex];
+
+            _fakeLocalTimeZone = new FakeLocalTimeZone(fakeTimeZoneInfo);
+        }
+
+        public void Dispose()
+        {
+            _fakeLocalTimeZone.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+
         [Fact]
         public void DateTimeAssignment_FullDayEvent_Success()
         {

--- a/src/Todoist.Net/Models/DueDate.cs
+++ b/src/Todoist.Net/Models/DueDate.cs
@@ -10,6 +10,7 @@ namespace Todoist.Net.Models
     /// </summary>
     public class DueDate
     {
+        private const string DefaultEventDateFormat = "yyyy-MM-ddTHH:mm:ssK"; // Roundtrip without milliseconds.
         private const string FullDayEventDateFormat = "yyyy-MM-dd";
 
         /// <summary>
@@ -124,13 +125,7 @@ namespace Todoist.Net.Models
                     return Date.Value.ToString(FullDayEventDateFormat);
                 }
 
-                var date = Date.Value.ToUniversalTime();
-                if (string.IsNullOrEmpty(Timezone))
-                {
-                    return date.ToString("s");
-                }
-
-                return date.ToString("s") + "Z";
+                return Date.Value.ToString(DefaultEventDateFormat);
             }
 
             set
@@ -143,7 +138,7 @@ namespace Todoist.Net.Models
                     return;
                 }
 
-                Date = DateTime.Parse(value, CultureInfo.InvariantCulture);
+                Date = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
             }
         }
     }


### PR DESCRIPTION
Fixes #36

**First**, existing unit tests for the [`DueDate`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Models/DueDate.cs) model should be modified to run on different time zones to ensure that date conversion works correctly no matter where it runs. 
That's why on the first commit, a [`FakeLocalTimeZone`](https://github.com/olsh/todoist-net/commit/40c93eeb9cb5e0b129e92191611cc9947e17fd4b#diff-81c531ff2bf0d248f92146af8b7301811f1e9a7727fdc400dbb889d0b0065685) helper class is added to mimic different time zones for tests when necessary (see this [SO question](https://stackoverflow.com/questions/44413407/mock-the-country-timezone-you-are-running-unit-test-from) for more details), which is used with the `DueDate` model tests to randomize the time zone in which tests are run.

**Second**, additional tests are added for the `DueDate` model to test the date conversion in the `StringDate` property getter and setter, which fail as expected.

**Last**, the `StringDate` to `Date` conversion process has been modified to use the [`DateTimeStyles.RoundtripKind`](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.datetimestyles?view=net-7.0#system-globalization-datetimestyles-roundtripkind) with the [`DateTime.Parse`](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.parse?view=net-7.0#parsing-and-style-elements) method. Then when converting back, the [round-trip](https://learn.microsoft.com/en-us/dotnet/standard/base-types/how-to-round-trip-date-and-time-values) format is used instead of the sortable-date format, with the exclusion of milliseconds.

**Note**: The `DueDate` floating date assignment unit test has been modified to use a date with [`DateTimeKind.Unspecified`](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind?view=net-7.0#system-datetimekind-unspecified) instead of [`DateTimeKind.Utc`](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind?view=net-7.0#system-datetimekind-utc) since floating dates are treated now as non-UTC dates.