### PR TITLE
Fix transaction failures for predefined temp_id of new entities

### DIFF
--- a/src/Todoist.Net.Tests/Services/TransactionTests.cs
+++ b/src/Todoist.Net.Tests/Services/TransactionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 using Todoist.Net.Models;
 using Todoist.Net.Tests.Extensions;
@@ -47,44 +48,44 @@ namespace Todoist.Net.Tests.Services
 
         [Fact]
         [Trait(Constants.TraitName, Constants.IntegrationFreeTraitValue)]
-        public void CreateProjectAndCreateItem_Success()
+        public async Task CreateProjectAndCreateItem_Success()
         {
             var client = TodoistClientFactory.Create(_outputHelper);
 
             var transaction = client.CreateTransaction();
 
             var project = new Project("Shopping List");
-            var projectId = transaction.Project.AddAsync(project).Result;
+            var projectId = await transaction.Project.AddAsync(project);
 
             var item = new Item("Buy milk")
             {
                 ProjectId = projectId
             };
-            transaction.Items.AddAsync(item).Wait();
+            await transaction.Items.AddAsync(item);
 
-            transaction.CommitAsync().Wait();
+            await transaction.CommitAsync();
 
             Assert.False(string.IsNullOrEmpty(project.Id.PersistentId));
             Assert.False(string.IsNullOrEmpty(item.Id.PersistentId));
 
 
-            var itemInfo = client.Items.GetAsync(item.Id).Result;
+            var itemInfo = await client.Items.GetAsync(item.Id);
 
             Assert.Equal(itemInfo.Item.Content, item.Content);
             Assert.Equal(itemInfo.Project.Name, project.Name);
             Assert.Equal(itemInfo.Project.Id.PersistentId, project.Id.PersistentId);
 
 
-            client.Projects.DeleteAsync(project.Id).Wait();
+            await client.Projects.DeleteAsync(project.Id);
 
-            var projects = client.Projects.GetAsync().Result;
+            var projects = await client.Projects.GetAsync();
 
             Assert.DoesNotContain(projects, p => p.Id.PersistentId == project.Id.PersistentId);
         }
 
         [Fact]
         [Trait(Constants.TraitName, Constants.IntegrationFreeTraitValue)]
-        public void CreateProjectAndCreateItemWithPredefinedTempId_Success()
+        public async Task CreateProjectAndCreateItemWithPredefinedTempId_Success()
         {
             var client = TodoistClientFactory.Create(_outputHelper);
 
@@ -99,25 +100,25 @@ namespace Todoist.Net.Tests.Services
 
             var transaction = client.CreateTransaction();
 
-            transaction.Project.AddAsync(project).Wait();
-            transaction.Items.AddAsync(item).Wait();
+            await transaction.Project.AddAsync(project);
+            await transaction.Items.AddAsync(item);
 
-            transaction.CommitAsync().Wait();
+            await transaction.CommitAsync();
 
             Assert.False(string.IsNullOrEmpty(project.Id.PersistentId));
             Assert.False(string.IsNullOrEmpty(item.Id.PersistentId));
 
 
-            var itemInfo = client.Items.GetAsync(item.Id).Result;
+            var itemInfo = await client.Items.GetAsync(item.Id);
 
             Assert.Equal(itemInfo.Item.Content, item.Content);
             Assert.Equal(itemInfo.Project.Name, project.Name);
             Assert.Equal(itemInfo.Project.Id.PersistentId, project.Id.PersistentId);
 
 
-            client.Projects.DeleteAsync(project.Id).Wait();
+            await client.Projects.DeleteAsync(project.Id);
 
-            var projects = client.Projects.GetAsync().Result;
+            var projects = await client.Projects.GetAsync();
 
             Assert.DoesNotContain(projects, p => p.Id.PersistentId == project.Id.PersistentId);
         }

--- a/src/Todoist.Net.Tests/Services/TransactionTests.cs
+++ b/src/Todoist.Net.Tests/Services/TransactionTests.cs
@@ -44,5 +44,83 @@ namespace Todoist.Net.Tests.Services
 
             deleteTransaction.CommitAsync().Wait();
         }
+
+        [Fact]
+        [Trait(Constants.TraitName, Constants.IntegrationFreeTraitValue)]
+        public void CreateProjectAndCreateItem_Success()
+        {
+            var client = TodoistClientFactory.Create(_outputHelper);
+
+            var transaction = client.CreateTransaction();
+
+            var project = new Project("Shopping List");
+            var projectId = transaction.Project.AddAsync(project).Result;
+
+            var item = new Item("Buy milk")
+            {
+                ProjectId = projectId
+            };
+            transaction.Items.AddAsync(item).Wait();
+
+            transaction.CommitAsync().Wait();
+
+            Assert.False(string.IsNullOrEmpty(project.Id.PersistentId));
+            Assert.False(string.IsNullOrEmpty(item.Id.PersistentId));
+
+
+            var itemInfo = client.Items.GetAsync(item.Id).Result;
+
+            Assert.Equal(itemInfo.Item.Content, item.Content);
+            Assert.Equal(itemInfo.Project.Name, project.Name);
+            Assert.Equal(itemInfo.Project.Id.PersistentId, project.Id.PersistentId);
+
+
+            client.Projects.DeleteAsync(project.Id).Wait();
+
+            var projects = client.Projects.GetAsync().Result;
+
+            Assert.DoesNotContain(projects, p => p.Id.PersistentId == project.Id.PersistentId);
+        }
+
+        [Fact]
+        [Trait(Constants.TraitName, Constants.IntegrationFreeTraitValue)]
+        public void CreateProjectAndCreateItemWithPredefinedTempId_Success()
+        {
+            var client = TodoistClientFactory.Create(_outputHelper);
+
+            var project = new Project("Shopping List")
+            {
+                Id = new ComplexId(Guid.NewGuid()) // predefined temp id
+            };
+            var item = new Item("Buy milk")
+            {
+                ProjectId = project.Id // predefined temp id
+            };
+
+            var transaction = client.CreateTransaction();
+
+            transaction.Project.AddAsync(project).Wait();
+            transaction.Items.AddAsync(item).Wait();
+
+            transaction.CommitAsync().Wait();
+
+            Assert.False(string.IsNullOrEmpty(project.Id.PersistentId));
+            Assert.False(string.IsNullOrEmpty(item.Id.PersistentId));
+
+
+            var itemInfo = client.Items.GetAsync(item.Id).Result;
+
+            Assert.Equal(itemInfo.Item.Content, item.Content);
+            Assert.Equal(itemInfo.Project.Name, project.Name);
+            Assert.Equal(itemInfo.Project.Id.PersistentId, project.Id.PersistentId);
+
+
+            client.Projects.DeleteAsync(project.Id).Wait();
+
+            var projects = client.Projects.GetAsync().Result;
+
+            Assert.DoesNotContain(projects, p => p.Id.PersistentId == project.Id.PersistentId);
+        }
+
     }
 }

--- a/src/Todoist.Net/Services/CommandServiceBase.cs
+++ b/src/Todoist.Net/Services/CommandServiceBase.cs
@@ -26,7 +26,11 @@ namespace Todoist.Net.Services
 
         internal Command CreateAddCommand<T>(CommandType commandType, T entity) where T : BaseEntity
         {
-            var tempId = Guid.NewGuid();
+            var tempId = entity.Id.TempId;
+            if (tempId == default)
+            {
+                tempId = Guid.NewGuid();
+            }
             entity.Id = tempId;
 
             return new Command(commandType, entity, tempId);

--- a/src/Todoist.Net/Services/CommandServiceBase.cs
+++ b/src/Todoist.Net/Services/CommandServiceBase.cs
@@ -27,7 +27,7 @@ namespace Todoist.Net.Services
         internal Command CreateAddCommand<T>(CommandType commandType, T entity) where T : BaseEntity
         {
             var tempId = entity.Id.TempId;
-            if (tempId == default)
+            if (tempId == Guid.Empty)
             {
                 tempId = Guid.NewGuid();
             }


### PR DESCRIPTION
Fixes #43 

- As suggested in the issue, extra tests were added to ensure that predefined `TempId` values for the create commands are working properly.
- The suggested fix for it was to check for existing `TempId` values first in [`CommandServiceBase.CreateAddCommand`](https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net/Services/CommandServiceBase.cs#L27) before creating new ones.