### PR TITLE
Add the option to include full task objects when getting completed tasks.

### DIFF
--- a/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
+++ b/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
@@ -23,33 +23,33 @@ namespace Todoist.Net.Tests.Services
 
         [Fact]
         [Trait(Constants.TraitName, Constants.IntegrationPremiumTraitValue)]
-        public void CreateItemCompleteGetCloseAsync_Success()
+        public async Task CreateItemCompleteGetCloseAsync_Success()
         {
             var client = TodoistClientFactory.Create(_outputHelper);
 
             var transaction = client.CreateTransaction();
 
             var item = new Item("temp task");
-            transaction.Items.AddAsync(item).Wait();
-            transaction.Notes.AddToItemAsync(new Note("test note"), item.Id).Wait();
-            transaction.Items.CloseAsync(item.Id).Wait();
+            await transaction.Items.AddAsync(item);
+            await transaction.Notes.AddToItemAsync(new Note("test note"), item.Id);
+            await transaction.Items.CloseAsync(item.Id);
 
-            transaction.CommitAsync().Wait();
+            await transaction.CommitAsync();
 
             var completedTasks =
-                client.Items.GetCompletedAsync(
+                await client.Items.GetCompletedAsync(
                     new ItemFilter()
                     {
                         AnnotateItems = true,
                         AnnotateNotes = true,
                         Limit = 5,
                         Since = DateTime.Today.AddDays(-1)
-                    }).Result;
+                    });
 
             Assert.True(completedTasks.Items.Count > 0);
             Assert.All(completedTasks.Items, i => Assert.NotNull(i.ItemObject));
 
-            client.Items.DeleteAsync(item.Id).Wait();
+            await client.Items.DeleteAsync(item.Id);
         }
 
         [Fact]

--- a/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
+++ b/src/Todoist.Net.Tests/Services/ItemsServiceTests.cs
@@ -38,9 +38,16 @@ namespace Todoist.Net.Tests.Services
 
             var completedTasks =
                 client.Items.GetCompletedAsync(
-                    new ItemFilter() { AnnotateNotes = true, Limit = 5, Since = DateTime.Today.AddDays(-1) }).Result;
+                    new ItemFilter()
+                    {
+                        AnnotateItems = true,
+                        AnnotateNotes = true,
+                        Limit = 5,
+                        Since = DateTime.Today.AddDays(-1)
+                    }).Result;
 
             Assert.True(completedTasks.Items.Count > 0);
+            Assert.All(completedTasks.Items, i => Assert.NotNull(i.ItemObject));
 
             client.Items.DeleteAsync(item.Id).Wait();
         }

--- a/src/Todoist.Net/Models/CompletedItem.cs
+++ b/src/Todoist.Net/Models/CompletedItem.cs
@@ -94,6 +94,10 @@ namespace Todoist.Net.Models
         /// <summary>
         /// Gets the full item object.
         /// </summary>
+        /// <remarks>
+        /// This property is only available when the <see cref="ItemFilter.AnnotateItems"/> property is set to <c>true</c> 
+        /// in the parameter passed to the <see cref="Services.IItemsService.GetCompletedAsync(ItemFilter, System.Threading.CancellationToken)"/> method.
+        /// </remarks>
         /// <value>
         /// The full item object.
         /// </value>

--- a/src/Todoist.Net/Models/CompletedItem.cs
+++ b/src/Todoist.Net/Models/CompletedItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Newtonsoft.Json;
@@ -90,5 +90,14 @@ namespace Todoist.Net.Models
         /// </value>
         [JsonProperty("user_id")]
         public long UserId { get; internal set; }
+
+        /// <summary>
+        /// Gets the full item object.
+        /// </summary>
+        /// <value>
+        /// The full item object.
+        /// </value>
+        [JsonProperty("item_object")]
+        public Item ItemObject { get; internal set; }
     }
 }

--- a/src/Todoist.Net/Models/ItemFilter.cs
+++ b/src/Todoist.Net/Models/ItemFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Todoist.Net.Extensions;
@@ -30,7 +30,7 @@ namespace Todoist.Net.Models
         /// Gets or sets the limit.
         /// </summary>
         /// <value>The limit.</value>
-        /// <remarks>Default is 30, and the maximum is 50.</remarks>
+        /// <remarks>Default is 30, and the maximum is 200.</remarks>
         public int? Limit { get; set; }
 
         /// <summary>

--- a/src/Todoist.Net/Models/ItemFilter.cs
+++ b/src/Todoist.Net/Models/ItemFilter.cs
@@ -11,6 +11,16 @@ namespace Todoist.Net.Models
     public class ItemFilter
     {
         /// <summary>
+        /// Gets or sets a value indicating whether to [annotate items].
+        /// </summary>
+        /// <remarks>
+        /// When this property is set to <c>true</c>, the <see cref="CompletedItem"/> returned will contain the
+        /// full item object contained in the <see cref="CompletedItem.ItemObject"/> property.
+        /// </remarks>
+        /// <value><c>null</c> if [annotate items] contains no value, <c>true</c> if [annotate items]; otherwise, <c>false</c>.</value>
+        public bool? AnnotateItems { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether [annotate notes].
         /// </summary>
         /// <value><c>null</c> if [annotate notes] contains no value, <c>true</c> if [annotate notes]; otherwise, <c>false</c>.</value>
@@ -79,6 +89,12 @@ namespace Todoist.Net.Models
             {
                 parameters.AddLast(
                     new KeyValuePair<string, string>("annotate_notes", AnnotateNotes == true ? "true" : "false"));
+            }
+
+            if (AnnotateItems.HasValue)
+            {
+                parameters.AddLast(
+                    new KeyValuePair<string, string>("annotate_items", AnnotateItems == true ? "true" : "false"));
             }
 
             return parameters;


### PR DESCRIPTION
As described in the [API documentation](https://developer.todoist.com/sync/v9/#get-all-completed-items), the expected response when we get completed tasks will include minimal data only by default.
However, there's a parameter that can be used to get full task data for that request, which is: `annotate_items`.

So, to use this parameter, the following changes were introduced:
- A property for the `annotate_items` parameter was added to the `ItemFilter` entity, called `ItemFilter.AnnotateItems`.
- A property for the full task object (`item_object`) was added to the `CompletedItem` entity, called `CompletedItem.ItemObject`.
- Tests were updated to check if the `annotate_items` parameter works as expected.