### PR TITLE
Include project notes in the NotesService Get response.

### DIFF
--- a/src/Todoist.Net.Tests/Services/NotesServiceTests.cs
+++ b/src/Todoist.Net.Tests/Services/NotesServiceTests.cs
@@ -33,8 +33,8 @@ namespace Todoist.Net.Tests.Services
             var note = new Note("Hello");
             await todoistClient.Notes.AddToProjectAsync(note, project.Id.PersistentId);
 
-            var notes = await todoistClient.Notes.GetAsync();
-            Assert.Contains(notes, n => n.Id == note.Id);
+            var notesInfo = await todoistClient.Notes.GetAsync();
+            Assert.Contains(notesInfo.ProjectNotes, n => n.Id == note.Id);
 
             await todoistClient.Projects.DeleteAsync(project.Id);
         }

--- a/src/Todoist.Net/Models/NotesInfo.cs
+++ b/src/Todoist.Net/Models/NotesInfo.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Todoist.Net.Models
+{
+    /// <summary>
+    /// Represents collections of item and project notes.
+    /// </summary>
+    public class NotesInfo
+    {
+        /// <summary>
+        /// Gets the item notes.
+        /// </summary>
+        /// <value>
+        /// The item notes.
+        /// </value>
+        public IReadOnlyCollection<Note> ItemNotes { get; internal set; }
+
+        /// <summary>
+        /// Gets the project notes.
+        /// </summary>
+        /// <value>
+        /// The project notes.
+        /// </value>
+        public IReadOnlyCollection<Note> ProjectNotes { get; internal set; }
+    }
+}

--- a/src/Todoist.Net/Services/INotesServices.cs
+++ b/src/Todoist.Net/Services/INotesServices.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,6 @@ namespace Todoist.Net.Services
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The notes.</returns>
         /// <exception cref="HttpRequestException">API exception.</exception>
-        Task<IEnumerable<Note>> GetAsync(CancellationToken cancellationToken = default);
+        Task<NotesInfo> GetAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Todoist.Net/Services/NotesService.cs
+++ b/src/Todoist.Net/Services/NotesService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,11 +18,15 @@ namespace Todoist.Net.Services
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Note>> GetAsync(CancellationToken cancellationToken = default)
+        public async Task<NotesInfo> GetAsync(CancellationToken cancellationToken = default)
         {
             var response = await TodoistClient.GetResourcesAsync(cancellationToken, ResourceType.Notes).ConfigureAwait(false);
 
-            return response.Notes;
+            return new NotesInfo
+            {
+                ItemNotes = response.Notes,
+                ProjectNotes = response.ProjectNotes
+            };
         }
     }
 }


### PR DESCRIPTION
As discussed in #47

The `NotesService.GetAsync` method was neglecting the returned project notes:

```c#
public async Task<IEnumerable<Note>> GetAsync(CancellationToken cancellationToken = default)
{
    var response = await TodoistClient.GetResourcesAsync(cancellationToken, ResourceType.Notes).ConfigureAwait(false);

    return response.Notes;
}
```

The new design returns a new model that contains both collections of notes:
```c#
public async Task<NotesInfo> GetAsync(CancellationToken cancellationToken = default)
{
    var response = await TodoistClient.GetResourcesAsync(cancellationToken, ResourceType.Notes).ConfigureAwait(false);

    return new NotesInfo
    {
        ItemNotes = response.Notes,
        ProjectNotes = response.ProjectNotes
    };
}
```