### PR TITLE
[Important] Switch to using `GET` instead of `POST` for `GET`-only endpoints

### DIFF
--- a/src/Todoist.Net.Tests/RateLimitAwareRestClient.cs
+++ b/src/Todoist.Net.Tests/RateLimitAwareRestClient.cs
@@ -54,6 +54,14 @@ namespace Todoist.Net.Tests
             return result;
         }
 
+        public async Task<HttpResponseMessage> GetAsync(
+            string resource,
+            IEnumerable<KeyValuePair<string, string>> parameters,
+            CancellationToken cancellationToken = default)
+        {
+            return await ExecuteRequest(() => _restClient.GetAsync(resource, parameters, cancellationToken)).ConfigureAwait(false);
+        }
+
         public async Task<HttpResponseMessage> PostAsync(
             string resource,
             IEnumerable<KeyValuePair<string, string>> parameters,

--- a/src/Todoist.Net/IAdvancedTodoistClient.cs
+++ b/src/Todoist.Net/IAdvancedTodoistClient.cs
@@ -94,18 +94,5 @@ namespace Todoist.Net
         /// </returns>
         /// <exception cref="HttpRequestException">API exception.</exception>
         Task<string> PostRawAsync(string resource, ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Processes the request asynchronous.
-        /// </summary>
-        /// <typeparam name="T">The type of the result.</typeparam>
-        /// <param name="resource">The resource.</param>
-        /// <param name="parameters">The parameters.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>
-        /// The result of the operation.
-        /// </returns>
-        /// <exception cref="HttpRequestException">API exception.</exception>
-        Task<T> ProcessPostAsync<T>(string resource, ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Todoist.Net/IAdvancedTodoistClient.cs
+++ b/src/Todoist.Net/IAdvancedTodoistClient.cs
@@ -53,7 +53,7 @@ namespace Todoist.Net
         Task<T> GetAsync<T>(string resource, ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Posts the request asynchronous.
+        /// Sends a <c>POST</c> request, and handles response asynchronously.
         /// </summary>
         /// <typeparam name="T">Type of the result.</typeparam>
         /// <param name="resource">The resource.</param>
@@ -66,7 +66,7 @@ namespace Todoist.Net
         Task<T> PostAsync<T>(string resource, ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Posts the asynchronous and returns a raw content.
+        /// Sends a <c>POST</c> request with form data, and handles response asynchronously.
         /// </summary>
         /// <typeparam name="T">The result type.</typeparam>
         /// <param name="resource">The resource.</param>
@@ -84,7 +84,7 @@ namespace Todoist.Net
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Posts the asynchronous and returns a raw content.
+        /// Sends a <c>POST</c> request asynchronously, and returns raw content.
         /// </summary>
         /// <param name="resource">The resource.</param>
         /// <param name="parameters">The parameters.</param>

--- a/src/Todoist.Net/IAdvancedTodoistClient.cs
+++ b/src/Todoist.Net/IAdvancedTodoistClient.cs
@@ -40,6 +40,19 @@ namespace Todoist.Net
         Task<string> ExecuteCommandsAsync(CancellationToken cancellationToken, params Command[] commands);
 
         /// <summary>
+        /// Sends a <c>GET</c> request, and handles response asynchronously.
+        /// </summary>
+        /// <typeparam name="T">Type of the result.</typeparam>
+        /// <param name="resource">The resource.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>
+        /// The result.
+        /// </returns>
+        /// <exception cref="HttpRequestException">API exception.</exception>
+        Task<T> GetAsync<T>(string resource, ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Posts the request asynchronous.
         /// </summary>
         /// <typeparam name="T">Type of the result.</typeparam>

--- a/src/Todoist.Net/ITodoistRestClient.cs
+++ b/src/Todoist.Net/ITodoistRestClient.cs
@@ -23,7 +23,7 @@ namespace Todoist.Net
         Task<HttpResponseMessage> GetAsync(string resource, IEnumerable<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Posts the asynchronous.
+        /// Sends a <c>POST</c> request, and handles response asynchronously.
         /// </summary>
         /// <param name="resource">The resource.</param>
         /// <param name="parameters">The parameters.</param>
@@ -34,7 +34,7 @@ namespace Todoist.Net
         Task<HttpResponseMessage> PostAsync(string resource, IEnumerable<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Posts the form asynchronous.
+        /// Sends a <c>POST</c> request with form data, and handles response asynchronously.
         /// </summary>
         /// <param name="resource">The resource.</param>
         /// <param name="parameters">The parameters.</param>

--- a/src/Todoist.Net/ITodoistRestClient.cs
+++ b/src/Todoist.Net/ITodoistRestClient.cs
@@ -12,6 +12,17 @@ namespace Todoist.Net
     public interface ITodoistRestClient : IDisposable
     {
         /// <summary>
+        /// Sends a <c>GET</c> request, and handles response asynchronously.
+        /// </summary>
+        /// <param name="resource">The resource.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Returns <see cref="T:System.Threading.Tasks.Task" />.The task object representing the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentException">Value cannot be null or empty - resource</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="parameters" /> is <see langword="null" /></exception>
+        Task<HttpResponseMessage> GetAsync(string resource, IEnumerable<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Posts the asynchronous.
         /// </summary>
         /// <param name="resource">The resource.</param>

--- a/src/Todoist.Net/Services/ActivityService.cs
+++ b/src/Todoist.Net/Services/ActivityService.cs
@@ -23,7 +23,7 @@ namespace Todoist.Net.Services
         {
             var parameters = filter != null ? filter.ToParameters() : new List<KeyValuePair<string, string>>();
 
-            return _todoistClient.PostAsync<Activity>("activity/get", parameters, cancellationToken);
+            return _todoistClient.GetAsync<Activity>("activity/get", parameters, cancellationToken);
         }
     }
 }

--- a/src/Todoist.Net/Services/BackupService.cs
+++ b/src/Todoist.Net/Services/BackupService.cs
@@ -21,7 +21,7 @@ namespace Todoist.Net.Services
         /// <inheritdoc/>
         public Task<IEnumerable<Backup>> GetAsync(CancellationToken cancellationToken = default)
         {
-            return _todoistClient.PostAsync<IEnumerable<Backup>>(
+            return _todoistClient.GetAsync<IEnumerable<Backup>>(
                 "backups/get",
                 new List<KeyValuePair<string, string>>(),
                 cancellationToken);

--- a/src/Todoist.Net/Services/ItemsService.cs
+++ b/src/Todoist.Net/Services/ItemsService.cs
@@ -50,7 +50,7 @@ namespace Todoist.Net.Services
         {
             var parameters = filter == null ? new List<KeyValuePair<string, string>>() : filter.ToParameters();
 
-            return TodoistClient.PostAsync<CompletedItemsInfo>("completed/get_all", parameters, cancellationToken);
+            return TodoistClient.GetAsync<CompletedItemsInfo>("completed/get_all", parameters, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Todoist.Net/Services/ProjectsService.cs
+++ b/src/Todoist.Net/Services/ProjectsService.cs
@@ -21,7 +21,7 @@ namespace Todoist.Net.Services
         /// <inheritdoc/>
         public Task<IEnumerable<Project>> GetArchivedAsync(CancellationToken cancellationToken = default)
         {
-            return TodoistClient.PostAsync<IEnumerable<Project>>(
+            return TodoistClient.GetAsync<IEnumerable<Project>>(
                 "projects/get_archived",
                 new List<KeyValuePair<string, string>>(),
                 cancellationToken);

--- a/src/Todoist.Net/Services/UploadService.cs
+++ b/src/Todoist.Net/Services/UploadService.cs
@@ -33,7 +33,7 @@ namespace Todoist.Net.Services
         /// <inheritdoc/>
         public Task<IEnumerable<Upload>> GetAsync(CancellationToken cancellationToken = default)
         {
-            return _todoistClient.PostAsync<IEnumerable<Upload>>(
+            return _todoistClient.GetAsync<IEnumerable<Upload>>(
                 "uploads/get",
                 new List<KeyValuePair<string, string>>(),
                 cancellationToken);

--- a/src/Todoist.Net/TodoistClient.cs
+++ b/src/Todoist.Net/TodoistClient.cs
@@ -319,7 +319,7 @@ namespace Todoist.Net
             ICollection<KeyValuePair<string, string>> parameters,
             CancellationToken cancellationToken)
         {
-            return ((IAdvancedTodoistClient)this).ProcessPostAsync<T>(resource, parameters, cancellationToken);
+            return ProcessPostAsync<T>(resource, parameters, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -357,8 +357,18 @@ namespace Todoist.Net
             return DeserializeResponse<T>(responseContent);
         }
 
-        /// <inheritdoc/>
-        async Task<T> IAdvancedTodoistClient.ProcessPostAsync<T>(
+        /// <summary>
+        /// Processes the request asynchronous.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="resource">The resource.</param>
+        /// <param name="parameters">The parameters.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>
+        /// The result of the operation.
+        /// </returns>
+        /// <exception cref="HttpRequestException">API exception.</exception>
+        private async Task<T> ProcessPostAsync<T>(
             string resource,
             ICollection<KeyValuePair<string, string>> parameters,
             CancellationToken cancellationToken)
@@ -400,7 +410,7 @@ namespace Todoist.Net
         /// <exception cref="HttpRequestException">API exception.</exception>
         private Task<T> ProcessSyncAsync<T>(ICollection<KeyValuePair<string, string>> parameters, CancellationToken cancellationToken)
         {
-            return ((IAdvancedTodoistClient)this).ProcessPostAsync<T>("sync", parameters, cancellationToken);
+            return ProcessPostAsync<T>("sync", parameters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Todoist.Net/TodoistClient.cs
+++ b/src/Todoist.Net/TodoistClient.cs
@@ -300,6 +300,21 @@ namespace Todoist.Net
         }
 
         /// <inheritdoc/>
+        async Task<T> IAdvancedTodoistClient.GetAsync<T>(
+            string resource,
+            ICollection<KeyValuePair<string, string>> parameters,
+            CancellationToken cancellationToken)
+        {
+            var response = await _restClient.GetAsync(resource, parameters, cancellationToken)
+                                .ConfigureAwait(false);
+
+            var responseContent = await ReadResponseAsync(response, cancellationToken)
+                                      .ConfigureAwait(false);
+
+            return DeserializeResponse<T>(responseContent);
+        }
+
+        /// <inheritdoc/>
         Task<T> IAdvancedTodoistClient.PostAsync<T>(
             string resource,
             ICollection<KeyValuePair<string, string>> parameters,

--- a/src/Todoist.Net/TodoistRestClient.cs
+++ b/src/Todoist.Net/TodoistRestClient.cs
@@ -52,6 +52,31 @@ namespace Todoist.Net
 
 
         /// <inheritdoc/>
+        public async Task<HttpResponseMessage> GetAsync(
+            string resource,
+            IEnumerable<KeyValuePair<string, string>> parameters,
+            CancellationToken cancellationToken = default)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(resource));
+            }
+
+            var requestUri = string.Empty;
+            using (var content = new FormUrlEncodedContent(parameters))
+            {
+                var query = await content.ReadAsStringAsync().ConfigureAwait(false);
+                requestUri = $"{resource}?{query}";
+            }
+            return await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public async Task<HttpResponseMessage> PostAsync(
             string resource,
             IEnumerable<KeyValuePair<string, string>> parameters,


### PR DESCRIPTION
### Issue:
Todoist developers have made a silly decision of removing support for some HTTP verbs for endpoints that accept both `GET` and `POST`. So, according to this [article](https://groups.google.com/a/doist.com/g/todoist-api/c/gtxV99qC-hE), some endpoints will only accept `GET` and the rest will only accept `POST`.

It was not explicitly stated in the [Sync API Docs](https://developer.todoist.com/sync/v9/) which endpoints should use `GET`, so, I had to look at each of their `curl` examples and found that the following endpoints accept `GET` by default:
- `projects/get_archived` ([#get-archived-projects](https://developer.todoist.com/sync/v9/#get-archived-projects))
- `completed/get_all` ([#get-all-completed-items](https://developer.todoist.com/sync/v9/#get-all-completed-items))
- `uploads/get` ([#get-uploads](https://developer.todoist.com/sync/v9/#get-uploads))
- `activity/get` ([#get-activity-logs](https://developer.todoist.com/sync/v9/#get-activity-logs))
- `backups/get` ([#get-backups](https://developer.todoist.com/sync/v9/#get-backups))
- `completed/get_stats` ([#get-productivity-stats](https://developer.todoist.com/sync/v9/#get-productivity-stats)) [**Not implemented by this package**]
- `archive/sections` ([#get-archived-sections](https://developer.todoist.com/sync/v9/#get-archived-sections)) [**Not implemented by this package**]
- `archive/items` ([#get-completed-items](https://developer.todoist.com/sync/v9/#get-completed-items)) [**Not implemented by this package**]
- `archive/items_many` ([#get-completed-items-with-a-list-of-parent-ids](https://developer.todoist.com/sync/v9/#get-completed-items-with-a-list-of-parent-ids)) [**Not implemented by this package**]

### Impact:
From the moment Todoist has made that change, all calls to the `ItemsService.GetCompletedAsync` method fail with the `405 Method Not Allowed`, regardless of the `Todoist.Net` version used.

### Fix:
- A `GetAsync` method was added to both `TodoistRestClient` and `TodoistClienery` similar to the `PostAsync` method.
- Then, each endpoint listed above was updated to use `GetAsync` instead of `PostAsync`.