### PR TITLE
Add support for dependency injection's IHttpClientFactory.

### DIFF
--- a/src/Todoist.Net/Extensions/TodoistServiceCollectionExtensions.cs
+++ b/src/Todoist.Net/Extensions/TodoistServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Todoist.Net.Extensions
@@ -21,3 +23,5 @@ namespace Todoist.Net.Extensions
         }
     }
 }
+
+#endif

--- a/src/Todoist.Net/Extensions/TodoistServiceCollectionExtensions.cs
+++ b/src/Todoist.Net/Extensions/TodoistServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Todoist.Net.Extensions
+{
+    /// <summary>
+    /// Extension methods for setting up todoist client services in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class TodoistServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds todoist client services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddTodoistClient(this IServiceCollection services)
+        {
+            services.AddHttpClient();
+            services.AddSingleton<ITodoistClientFactory, TodoistClientFactory>();
+
+            return services;
+        }
+    }
+}

--- a/src/Todoist.Net/ITodoistClientFactory.cs
+++ b/src/Todoist.Net/ITodoistClientFactory.cs
@@ -1,0 +1,15 @@
+namespace Todoist.Net
+{
+    /// <summary>
+    /// A factory abstraction for a component that can create <see cref="TodoistClient"/> instances with user tokens.
+    /// </summary>
+    public interface ITodoistClientFactory
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="TodoistClient"/> with the specified user token."/>
+        /// </summary>
+        /// <param name="token">The user token to use.</param>
+        /// <returns>The created <see cref="TodoistClient"/></returns>
+        TodoistClient CreateClient(string token);
+    }
+}

--- a/src/Todoist.Net/Todoist.Net.csproj
+++ b/src/Todoist.Net/Todoist.Net.csproj
@@ -25,9 +25,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Todoist.Net/Todoist.Net.csproj
+++ b/src/Todoist.Net/Todoist.Net.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>

--- a/src/Todoist.Net/TodoistClientFactory.cs
+++ b/src/Todoist.Net/TodoistClientFactory.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0
+
 using System.Net.Http;
 
 namespace Todoist.Net
@@ -21,3 +23,5 @@ namespace Todoist.Net
         }
     }
 }
+
+#endif

--- a/src/Todoist.Net/TodoistClientFactory.cs
+++ b/src/Todoist.Net/TodoistClientFactory.cs
@@ -1,0 +1,23 @@
+using System.Net.Http;
+
+namespace Todoist.Net
+{
+    internal sealed class TodoistClientFactory : ITodoistClientFactory
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public TodoistClientFactory(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        /// <inheritdoc/>
+        public TodoistClient CreateClient(string token)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            var todoistRestClient = new TodoistRestClient(token, httpClient);
+
+            return new TodoistClient(todoistRestClient);
+        }
+    }
+}

--- a/src/Todoist.Net/TodoistRestClient.cs
+++ b/src/Todoist.Net/TodoistRestClient.cs
@@ -11,12 +11,13 @@ namespace Todoist.Net
     internal sealed class TodoistRestClient : ITodoistRestClient
     {
         private readonly HttpClient _httpClient;
+        private readonly bool _disposeHttpClient;
 
-        public TodoistRestClient() : this(null, null)
+        public TodoistRestClient() : this(null, (IWebProxy)null)
         {
         }
 
-        public TodoistRestClient(string token) : this(token, null)
+        public TodoistRestClient(string token) : this(token, (IWebProxy)null)
         {
         }
 
@@ -43,11 +44,27 @@ namespace Todoist.Net
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             }
+
+            _disposeHttpClient = true;
+        }
+
+        public TodoistRestClient(string token, HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+
+            _httpClient.BaseAddress = new Uri("https://api.todoist.com/sync/v9/");
+            if (!string.IsNullOrEmpty(token))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
         }
 
         public void Dispose()
         {
-            _httpClient?.Dispose();
+            if (_disposeHttpClient)
+            {
+                _httpClient?.Dispose(); 
+            }
         }
 
 


### PR DESCRIPTION
Picking up from #54 (Closes #54)

### Changes:
1. Added a constructor overload for `TodoistRestClient` that takes an `HttpClient` instance as an argument:
```csharp
public TodoistRestClient(string token, HttpClient httpClient)
{
    _httpClient = httpClient;

    _httpClient.BaseAddress = new Uri("https://api.todoist.com/sync/v9/");
    if (!string.IsNullOrEmpty(token))
    {
        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
    }
}
```
2. Created an `ITodoistClientFactory` interface and `TodoistClientFactory` implementation to inject into the DI container, and use the provided `IHttpClientFactory`:
```csharp
public interface ITodoistClientFactory
{
    TodoistClient CreateClient(string token);
}

internal sealed class TodoistClientFactory : ITodoistClientFactory
{
    private readonly IHttpClientFactory _httpClientFactory;

    public TodoistClientFactory(IHttpClientFactory httpClientFactory)
    {
        _httpClientFactory = httpClientFactory;
    }

    public TodoistClient CreateClient(string token)
    {
        var httpClient = _httpClientFactory.CreateClient();
        var todoistRestClient = new TodoistRestClient(token, httpClient);

        return new TodoistClient(todoistRestClient);
    }
}
```
3. Added an extension method to inject both the `ITodoistClientFactory` and `IHttpClientFactory`:
```csharp
public static class TodoistServiceCollectionExtensions
{
    public static IServiceCollection AddTodoistClient(this IServiceCollection services)
    {
        services.AddHttpClient();
        services.AddSingleton<ITodoistClientFactory, TodoistClientFactory>();

        return services;
    }
}
```