### PR TITLE
Add two-workflow CI for SonarCloud fork PR analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.x
+        dotnet-version: 10.x
 
     - name: Setup Java
       uses: actions/setup-java@v5
@@ -38,10 +40,31 @@ jobs:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
 
-    - name: Build and Test
+    - name: Build, Test and Sonar (push)
+      if: github.event_name == 'push'
       run: .\build.cmd sonar unit-test nuget-pack --configuration Release
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    - name: Build and Test (PR)
+      if: github.event_name == 'pull_request'
+      run: .\build.cmd unit-test nuget-pack --configuration Release
+
+    - name: Save PR metadata
+      if: github.event_name == 'pull_request'
+      run: |
+        mkdir pr-metadata
+        echo "${{ github.event.pull_request.number }}" > pr-metadata/pr_number
+        echo "${{ github.event.pull_request.base.ref }}" > pr-metadata/pr_base
+        echo "${{ github.event.pull_request.head.ref }}" > pr-metadata/pr_branch
+        echo "${{ github.event.pull_request.head.sha }}" > pr-metadata/pr_sha
+
+    - name: Upload PR metadata
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-metadata
+        path: pr-metadata/
 
     - name: Upload NuGet package
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         dotnet-version: 10.x
 
     - name: Setup Java
+      if: github.event_name == 'push'
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
@@ -35,6 +36,7 @@ jobs:
           ${{ runner.os }}-nuget-
 
     - name: Cache SonarQube
+      if: github.event_name == 'push'
       uses: actions/cache@v4
       with:
         path: ~/.sonar/cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.x
+        dotnet-version: 10.x
 
     - name: Cache NuGet packages
       uses: actions/cache@v4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,84 @@
+name: Sonar
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  sonar:
+    runs-on: windows-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+
+    steps:
+    - name: Download PR metadata
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.payload.workflow_run.id,
+          });
+          const matchArtifact = artifacts.data.artifacts.find(a => a.name === 'pr-metadata');
+          if (!matchArtifact) {
+            core.setFailed('PR metadata artifact not found');
+            return;
+          }
+          const download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: matchArtifact.id,
+            archive_format: 'zip',
+          });
+          const fs = require('fs');
+          fs.writeFileSync('${{ runner.temp }}/pr-metadata.zip', Buffer.from(download.data));
+
+    - name: Extract PR metadata
+      run: |
+        Expand-Archive -Path "${{ runner.temp }}/pr-metadata.zip" -DestinationPath "${{ runner.temp }}/pr-metadata"
+        echo "PR_NUMBER=$(Get-Content '${{ runner.temp }}/pr-metadata/pr_number')" >> $env:GITHUB_ENV
+        echo "PR_BASE=$(Get-Content '${{ runner.temp }}/pr-metadata/pr_base')" >> $env:GITHUB_ENV
+        echo "PR_BRANCH=$(Get-Content '${{ runner.temp }}/pr-metadata/pr_branch')" >> $env:GITHUB_ENV
+        echo "PR_SHA=$(Get-Content '${{ runner.temp }}/pr-metadata/pr_sha')" >> $env:GITHUB_ENV
+
+    - uses: actions/checkout@v5
+      with:
+        ref: ${{ env.PR_SHA }}
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.x
+
+    - name: Setup Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Cache SonarQube
+      uses: actions/cache@v4
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+
+    - name: Run Sonar Analysis
+      run: |
+        .\build.cmd sonar --configuration Release `
+          --pr-number ${{ env.PR_NUMBER }} `
+          --pr-base ${{ env.PR_BASE }} `
+          --pr-branch ${{ env.PR_BRANCH }}
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Todoist.Net.sln
+++ b/Todoist.Net.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml
+		.github\workflows\sonar.yml = .github\workflows\sonar.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Todoist.Net", "src\Todoist.Net\Todoist.Net.csproj", "{0D84413B-43C0-4F0E-92A6-669F2E9EA5CB}"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,6 +19,10 @@ class Build : NukeBuild
 
     [Parameter("SonarQube token", Name = "SONAR_TOKEN")] readonly string SonarQubeToken;
 
+    [Parameter("Pull request number")] readonly int? PrNumber;
+    [Parameter("Pull request base branch")] readonly string PrBase;
+    [Parameter("Pull request head branch")] readonly string PrBranch;
+
     [Solution(GenerateProjects = true)] readonly Solution Solution;
 
     [CI] readonly GitHubActions GitHubActions;
@@ -83,7 +87,15 @@ class Build : NukeBuild
                     .SetVersion("1.0.0.0")
                     .SetAdditionalParameters(new Dictionary<string, string> { ["sonar.scanner.skipJreProvisioning"] = "true" });
 
-                if (GitHubActions != null)
+                // Priority: CLI params > GitHubActions context
+                if (PrNumber.HasValue)
+                {
+                    s = s
+                        .SetPullRequestKey(PrNumber.Value.ToString())
+                        .SetPullRequestBase(PrBase)
+                        .SetPullRequestBranch(PrBranch);
+                }
+                else if (GitHubActions != null)
                 {
                     if (GitHubActions.IsPullRequest)
                     {


### PR DESCRIPTION
## Summary
- Split CI into two workflows to enable SonarCloud analysis for PRs from forks
- CI workflow builds and tests PRs, saves PR metadata as artifact
- Sonar workflow triggers on workflow_run completion, has access to secrets, runs analysis with PR parameters
- Update all workflows to use .NET 10.x
- Add fetch-depth: 0 for full git history (improves Sonar blame accuracy)

## Test plan
- [ ] Verify push to master runs full CI with Sonar analysis
- [ ] Verify PR from same repo runs CI without Sonar, then Sonar workflow triggers
- [ ] Verify SonarCloud receives the PR analysis with correct PR metadata