### PR TITLE
Fix two endpoints the API v1 migration left on v9 routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 A [Todoist API](https://developer.todoist.com) client for .NET.
 
+> **Upgrading from 10.x?** Version 11.0.0 moves to the unified Todoist API v1 and renames much of
+> the public surface (`Items` -> `Tasks`, `Notes` -> `Comments`, and more). See the
+> [11.0.0 release notes](https://github.com/olsh/todoist-net/releases/tag/11.0.0) for the full
+> migration table.
+
 ## Installation
 
 The library is available as a [Nuget package](https://www.nuget.org/packages/Todoist.Net/).
@@ -30,13 +35,13 @@ var task = await client.Tasks.QuickAddAsync(quickAddTask);
 ### Simple API calls
 ```csharp
 // Get all resources (labels, projects, tasks, comments etc.).
-var resources = await client.GetResourcesAsync();
+var resources = await client.SyncResourcesAsync();
 
 // Get only projects and labels.
-var projectsAndLabels = await client.GetResourcesAsync(ResourceType.Projects, ResourceType.Labels);
+var projectsAndLabels = await client.SyncResourcesAsync(new[] { ResourceType.Projects, ResourceType.Labels });
 
 // Get only projects.
-var projectsOnly = await client.GetResourcesAsync(ResourceType.Projects);
+var projectsOnly = await client.SyncResourcesAsync(new[] { ResourceType.Projects });
 
 // Alternatively you can use this API to get projects.
 var projects = await client.Projects.GetAsync();
@@ -49,13 +54,13 @@ await client.Comments.AddToTaskAsync(new Comment("Task description"), taskId);
 ### Transactions (Batching)
 Batching: reading and writing of multiple resources can be done in a single HTTP request.
 
-Add a new project, task and note in one request.
+Add a new project, task and comment in one request.
 ```csharp
 // Create a new transaction.
 var transaction = client.CreateTransaction();
 
 // These requests are queued and will be executed later.
-var projectId = await transaction.Project.AddAsync(new Project("New project"));
+var projectId = await transaction.Projects.AddAsync(new AddProject("New project"));
 var taskId = await transaction.Tasks.AddAsync(new AddTask("New task", projectId));
 await transaction.Comments.AddToTaskAsync(new Comment("Task description"), taskId);
 

--- a/src/Todoist.Net.Tests/Helpers/StubTodoistRestClient.cs
+++ b/src/Todoist.Net.Tests/Helpers/StubTodoistRestClient.cs
@@ -8,12 +8,16 @@ internal sealed class StubTodoistRestClient : ITodoistRestClient
     private Func<string, Dictionary<string, string>, CancellationToken, Task<HttpResponseMessage>>? _getAsyncHandler;
     private Func<string, Dictionary<string, string>, CancellationToken, Task<HttpResponseMessage>>? _postAsyncHandler;
     private Func<string, Dictionary<string, string>, CancellationToken, Task<HttpResponseMessage>>? _deleteAsyncHandler;
+    private Func<string, string, CancellationToken, Task<HttpResponseMessage>>? _postJsonAsyncHandler;
+    private Func<string, string, CancellationToken, Task<HttpResponseMessage>>? _putJsonAsyncHandler;
 
     public string LastResource { get; private set; } = string.Empty;
 
     public Dictionary<string, string> LastQueryParams { get; private set; } = [];
 
     public Dictionary<string, string> LastFormParams { get; private set; } = [];
+
+    public string LastJsonContent { get; private set; } = string.Empty;
 
     public void RespondToGetJson(HttpStatusCode statusCode, string json)
     {
@@ -23,6 +27,16 @@ internal sealed class StubTodoistRestClient : ITodoistRestClient
     public void RespondToPostJson(HttpStatusCode statusCode, string json)
     {
         _postAsyncHandler = (_, _, _) => Task.FromResult(CreateJsonResponse(statusCode, json));
+    }
+
+    public void RespondToJsonPost(HttpStatusCode statusCode, string json)
+    {
+        _postJsonAsyncHandler = (_, _, _) => Task.FromResult(CreateJsonResponse(statusCode, json));
+    }
+
+    public void RespondToJsonPut(HttpStatusCode statusCode, string json)
+    {
+        _putJsonAsyncHandler = (_, _, _) => Task.FromResult(CreateJsonResponse(statusCode, json));
     }
 
     public void RespondToDeleteWithEmptyBody(HttpStatusCode statusCode)
@@ -55,7 +69,11 @@ internal sealed class StubTodoistRestClient : ITodoistRestClient
 
     public Task<HttpResponseMessage> PostJsonAsync(string resource, string jsonContent, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException();
+        LastResource = resource;
+        LastJsonContent = jsonContent;
+
+        return _postJsonAsyncHandler?.Invoke(resource, jsonContent, cancellationToken)
+            ?? throw new NotSupportedException("No JSON POST handler configured.");
     }
 
     public Task<HttpResponseMessage> PutAsync(string resource, CancellationToken cancellationToken = default)
@@ -65,7 +83,11 @@ internal sealed class StubTodoistRestClient : ITodoistRestClient
 
     public Task<HttpResponseMessage> PutJsonAsync(string resource, string jsonContent, CancellationToken cancellationToken = default)
     {
-        throw new NotSupportedException();
+        LastResource = resource;
+        LastJsonContent = jsonContent;
+
+        return _putJsonAsyncHandler?.Invoke(resource, jsonContent, cancellationToken)
+            ?? throw new NotSupportedException("No JSON PUT handler configured.");
     }
 
     public Task<HttpResponseMessage> DeleteAsync(string resource, Dictionary<string, string>? queryParams = null, CancellationToken cancellationToken = default)

--- a/src/Todoist.Net.Tests/Services/UtilityServicesTests.cs
+++ b/src/Todoist.Net.Tests/Services/UtilityServicesTests.cs
@@ -43,6 +43,40 @@ public class UtilityServicesTests
 
     [Fact]
     [Trait(Constants.TraitName, Constants.IntegrationPremiumTraitValue)]
+    public async Task CreateTask_GetOrCreateEmail_Disable_Succeeds()
+    {
+        var newProject = TestData.Projects.AddProject($"UtilityEmailTaskProject_{Guid.NewGuid():N}");
+        var newTask = TestData.Tasks.AddTask(newProject.Id, $"UtilityEmailTask_{Guid.NewGuid():N}");
+
+
+        // Step 1: Create project and task.
+        await _apiFixture.PremiumClient.Projects.AddAsync(newProject, _cancellationToken);
+        await using var projectTracker = _apiFixture.TrackForCleanup(newProject, c => c.Projects.DeleteAsync, isPremium: true);
+
+        await _apiFixture.PremiumClient.Tasks.AddAsync(newTask, _cancellationToken);
+        await using var taskTracker = _apiFixture.TrackForCleanup(newTask, c => c.Tasks.DeleteAsync, isPremium: true);
+
+
+        // Step 2: Get or create task email. The API only accepts the "task" object type here,
+        // the legacy "item" value is rejected.
+        var actualEmail = await _apiFixture.PremiumClient.Emails.GetOrCreateAsync(
+            EmailObjectType.Task,
+            newTask.Id.PersistentId,
+            _cancellationToken);
+
+        Assert.NotNull(actualEmail);
+        Assert.False(string.IsNullOrWhiteSpace(actualEmail.Email));
+
+
+        // Step 3: Disable task email.
+        await _apiFixture.PremiumClient.Emails.DisableAsync(
+            EmailObjectType.Task,
+            newTask.Id.PersistentId,
+            _cancellationToken);
+    }
+
+    [Fact]
+    [Trait(Constants.TraitName, Constants.IntegrationPremiumTraitValue)]
     public async Task CreateTask_GetIdMappings_Succeeds()
     {
         var newProject = TestData.Projects.AddProject($"UtilityActivityProject_{Guid.NewGuid():N}");

--- a/src/Todoist.Net.Tests/TodoistClientProtocolTests.cs
+++ b/src/Todoist.Net.Tests/TodoistClientProtocolTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 
 namespace Todoist.Net.Tests;
 
@@ -297,6 +298,74 @@ public class TodoistClientProtocolTests
         Assert.Equal("today", restClient.LastQueryParams["filter_query"]);
         Assert.Equal("en", restClient.LastQueryParams["filter_lang"]);
         Assert.False(restClient.LastQueryParams.ContainsKey("filter"));
+    }
+
+    [Fact]
+    public async Task ImportTemplateIntoProject_AddressesTheTemplateIdEndpoint()
+    {
+        var restClient = new StubTodoistRestClient();
+        restClient.RespondToJsonPost(
+            HttpStatusCode.OK,
+            """
+            {
+                "status": "ok",
+                "projects": [],
+                "sections": [],
+                "tasks": [],
+                "comments": [],
+                "project_notes": []
+            }
+            """);
+        using var todoistClient = new TodoistClient(restClient);
+
+
+        // Step 1: Import a saved template into an existing project.
+        await todoistClient.Templates.ImportIntoProjectAsync(
+            "6X7rM8997g3RQmvh",
+            "123456",
+            TestContext.Current.CancellationToken);
+
+
+        // Step 2: Assert the v1 route is used. The v9 `templates/import_into_project` route was split
+        // into a file variant and this template ID variant, and the retired route answers every
+        // request with the same generic `NOT_FOUND` error, so only the URL itself pins this down.
+        Assert.Equal("templates/import_into_project_from_template_id", restClient.LastResource);
+
+        using var requestBody = JsonDocument.Parse(restClient.LastJsonContent);
+        Assert.Equal("6X7rM8997g3RQmvh", requestBody.RootElement.GetProperty("project_id").GetString());
+        Assert.Equal("123456", requestBody.RootElement.GetProperty("template_id").GetString());
+    }
+
+    [Fact]
+    public async Task GetOrCreateEmail_ForATask_SendsTheTaskObjectType()
+    {
+        var restClient = new StubTodoistRestClient();
+        restClient.RespondToJsonPut(
+            HttpStatusCode.OK,
+            """
+            {
+                "email": "sdk-tests@in.todoist.com"
+            }
+            """);
+        using var todoistClient = new TodoistClient(restClient);
+
+
+        // Step 1: Get or create the email of a task.
+        var actualEmail = await todoistClient.Emails.GetOrCreateAsync(
+            EmailObjectType.Task,
+            "6X7rM8997g3RQmvh",
+            TestContext.Current.CancellationToken);
+
+
+        // Step 2: Assert the object type is sent as `task`. The legacy `item` value is still accepted
+        // when disabling an email, but it is rejected here.
+        Assert.Equal("emails", restClient.LastResource);
+
+        using var requestBody = JsonDocument.Parse(restClient.LastJsonContent);
+        Assert.Equal("task", requestBody.RootElement.GetProperty("obj_type").GetString());
+        Assert.Equal("6X7rM8997g3RQmvh", requestBody.RootElement.GetProperty("obj_id").GetString());
+
+        Assert.Equal("sdk-tests@in.todoist.com", actualEmail.Email);
     }
 
     [Fact]

--- a/src/Todoist.Net/Models/Commands/CommandType.cs
+++ b/src/Todoist.Net/Models/Commands/CommandType.cs
@@ -17,6 +17,10 @@ namespace Todoist.Net.Models
         public static CommandType DeleteWorkspaceFolder { get; } = new CommandType("folder_delete");
 
         public static CommandType UpdateWorkspaceUser { get; } = new CommandType("workspace_update_user");
+        // The docs document this command as `workspace_update_user_sidebar_preference` taking a
+        // `sidebar_preference` argument, but the deployed API rejects that name with INVALID_COMMAND,
+        // exactly as it rejects a name that does not exist. The response field is still
+        // `project_sort_preference` too, so keep both as they are until the API actually changes.
         public static CommandType UpdateWorkspaceUserProjectSortPreference { get; } = new CommandType("workspace_update_user_project_sort_preference");
         public static CommandType DeleteWorkspaceUser { get; } = new CommandType("workspace_delete_user");
         public static CommandType InviteWorkspaceUsers { get; } = new CommandType("workspace_invite");

--- a/src/Todoist.Net/Models/Emails/EmailObjectType.cs
+++ b/src/Todoist.Net/Models/Emails/EmailObjectType.cs
@@ -15,15 +15,12 @@ namespace Todoist.Net.Models
         }
 
         /// <summary>
-        /// Gets the item type.
+        /// Gets the task type.
         /// </summary>
-        /// <remarks>
-        /// Todoist API uses the legacy "item" string for tasks in sync endpoints.
-        /// </remarks>
         /// <value>
-        /// The item type.
+        /// The task type.
         /// </value>
-        public static EmailObjectType Item { get; } = new EmailObjectType("item");
+        public static EmailObjectType Task { get; } = new EmailObjectType("task");
 
         /// <summary>
         /// Gets the project type.

--- a/src/Todoist.Net/Services/Templates/TemplatesService.cs
+++ b/src/Todoist.Net/Services/Templates/TemplatesService.cs
@@ -55,7 +55,7 @@ namespace Todoist.Net.Services
             };
 
             return TodoistClient.PostJsonAsync<TemplateImportRequest, TemplateImportResult>(
-                "templates/import_into_project", body, cancellationToken);
+                "templates/import_into_project_from_template_id", body, cancellationToken);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Audit of the API v1 migration against the official OpenAPI spec, the v1 Sync
command docs and the Doist Python client, ahead of the 11.0.0 release.

The migration itself holds up: base URL, all 76 sync command strings, all 28
`ResourceType` values, the three pagination envelopes, every GET parameter set
and the read models all match the spec. Two calls were still addressing v9
routes.

### `templates/import_into_project`

Removed in v1 and split into `import_into_project_from_file` (already used) and
`import_into_project_from_template_id`. The template ID overload still pointed
at the retired path. Verified against the live API that the old route answers
every request with the same generic `NOT_FOUND`, whatever the arguments, so the
failure was indistinguishable from a genuinely missing template — and only the
file overload had a test.

### `EmailObjectType.Item`

`PUT /emails` accepts `project`, `project_comments` and `task`; `item` survives
only as an alias on `DELETE /emails`. Renamed to `EmailObjectType.Task`, which
is a breaking change and so belongs in this major.

### Tests

Both routes fail identically from the outside, so they are pinned with protocol
tests asserting the request URI and body — those carry the `unit` trait, which
is what CI actually gates on. That required teaching `StubTodoistRestClient` to
handle JSON POST/PUT, which it previously refused outright. An integration test
covers the task email round trip.

Full suite: 71 passed, 6 failed — all six environmental (four need
`todoist_token_secondary`, two hit `MAX_FREE_WORKSPACES_CREATED` on the test
account). No code failures.

### README

It ships inside the package via `PackageReadmeFile` and its examples no longer
compiled: `GetResourcesAsync`, `new Project(...)` and `transaction.Project` are
all gone. Added an upgrade pointer for 10.x users.

### Also

The v1 docs rename the workspace sort preference command to
`workspace_update_user_sidebar_preference`, but the deployed API rejects that
name with `INVALID_COMMAND` exactly as it rejects a name that never existed,
while the current name is still dispatched. Recorded in a comment so the next
reader of the docs does not "fix" working code.