### PR TITLE
Read project data tasks from the v1 property name

### DIFF
--- a/src/Todoist.Net.Tests/Services/ProjectsServiceTests.cs
+++ b/src/Todoist.Net.Tests/Services/ProjectsServiceTests.cs
@@ -79,6 +79,33 @@ public class ProjectsServiceTests
     }
 
     [Fact]
+    public async Task CreateProjectWithTask_GetData_ReturnsTheTask()
+    {
+        var newProject = new AddProject($"ProjectDataUnderTest_{Guid.NewGuid():N}");
+        var expectedTaskContent = $"ProjectDataTask_{Guid.NewGuid():N}";
+
+
+        // Step 1: Create a project and seed it with a task.
+        await _apiFixture.Client.Projects.AddAsync(newProject, _cancellationToken);
+        await using var projectTracker = _apiFixture.TrackForCleanup(newProject, c => c.Projects.DeleteAsync);
+
+        var newTask = TestData.Tasks.AddTask(newProject.Id, expectedTaskContent);
+        await _apiFixture.Client.Tasks.AddAsync(newTask, _cancellationToken);
+
+
+        // Step 2: Read the full project data back.
+        var actualProjectData = await _apiFixture.Client.Projects.GetDataAsync(
+            newProject.Id.PersistentId,
+            _cancellationToken);
+
+        Assert.NotNull(actualProjectData.Project);
+        Assert.Equal(newProject.Name, actualProjectData.Project.Name);
+
+        Assert.NotNull(actualProjectData.Tasks);
+        Assert.Contains(actualProjectData.Tasks, t => t.Content == expectedTaskContent);
+    }
+
+    [Fact]
     public async Task CreateProject_UpdateAndSetViewOptions_Archive_GetAndGetArchived_Unarchive_Succeeds()
     {
         // Step 0: Create project for arrangement of the test.

--- a/src/Todoist.Net.Tests/TodoistClientProtocolTests.cs
+++ b/src/Todoist.Net.Tests/TodoistClientProtocolTests.cs
@@ -301,6 +301,43 @@ public class TodoistClientProtocolTests
     }
 
     [Fact]
+    public async Task GetProjectData_ReadsTasksFromTheV1PropertyName()
+    {
+        var restClient = new StubTodoistRestClient();
+        restClient.RespondToGetJson(
+            HttpStatusCode.OK,
+            """
+            {
+                "project": { "id": "6Crcmx9Mrpphc3Qc", "name": "Shopping" },
+                "tasks": [ { "id": "6X7rM8997g3RQmvh", "content": "Buy Milk" } ],
+                "sections": [],
+                "subprojects": [],
+                "collaborators": [],
+                "collaborator_states": [],
+                "comments_count": 3,
+                "folder": null
+            }
+            """);
+        using var todoistClient = new TodoistClient(restClient);
+
+
+        // Step 1: Get the full data of a project.
+        var actualProjectData = await todoistClient.Projects.GetDataAsync(
+            "6Crcmx9Mrpphc3Qc",
+            TestContext.Current.CancellationToken);
+
+
+        // Step 2: Assert the tasks are read. This endpoint answers with the v1 name "tasks", not the
+        // "items" the sync endpoint still uses, so binding it to "items" left `Tasks` silently null.
+        Assert.Equal("projects/6Crcmx9Mrpphc3Qc/full", restClient.LastResource);
+
+        var actualTask = Assert.Single(actualProjectData.Tasks);
+        Assert.Equal("Buy Milk", actualTask.Content);
+        Assert.Equal("Shopping", actualProjectData.Project.Name);
+        Assert.Equal(3, actualProjectData.CommentsCount);
+    }
+
+    [Fact]
     public async Task ImportTemplateIntoProject_AddressesTheTemplateIdEndpoint()
     {
         var restClient = new StubTodoistRestClient();

--- a/src/Todoist.Net/Models/Projects/ProjectData.cs
+++ b/src/Todoist.Net/Models/Projects/ProjectData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -9,13 +10,21 @@ namespace Todoist.Net.Models
     public class ProjectData
     {
         /// <summary>Gets the tasks.</summary>
-        /// <remarks>The JSON property name remains "items" for backwards compatibility with Sync API.</remarks>
-        [JsonPropertyName("items")]
+        /// <remarks>
+        /// Unlike the sync endpoint, which still answers with "items", this REST endpoint uses the
+        /// v1 name "tasks".
+        /// </remarks>
+        [JsonPropertyName("tasks")]
         public IReadOnlyCollection<TaskInfo> Tasks { get; internal set; }
 
+        /// <summary>Gets the number of comments on the project.</summary>
+        [JsonPropertyName("comments_count")]
+        public int CommentsCount { get; internal set; }
+
         /// <summary>Gets the comments.</summary>
-        /// <remarks>The JSON property name remains "project_notes" for backwards compatibility with Sync API.</remarks>
-        [JsonPropertyName("project_notes")]
+        /// <remarks>Always <see langword="null" />: the endpoint returns <see cref="CommentsCount" /> instead of the comments themselves.</remarks>
+        [Obsolete("The endpoint no longer returns project comments, only their count. Use CommentsCount, or ICommentsService.GetAsync to read the comments.")]
+        [JsonIgnore]
         public IReadOnlyCollection<Comment> ProjectComments { get; internal set; }
 
         /// <summary>Gets the collaborators.</summary>


### PR DESCRIPTION
Fixes the bug @rossdargan reported in #70, which is still present in 11.0.0.

`GET projects/{id}/full` answers with a `tasks` array, but `ProjectData.Tasks`
was bound to `items`, on the assumption that this endpoint keeps the sync
protocol's legacy naming. That rule holds for the *sync* endpoint, not for REST
v1 routes, so `Tasks` deserialized to `null` while `Project` was populated —
exactly the symptom reported.

Verified against the live API; the response is:

```
project, tasks, sections, subprojects, collaborators,
collaborator_states, comments_count, folder
```

So `project_notes` is gone too — the endpoint returns `comments_count` instead.
`CommentsCount` is added, and `ProjectComments` is marked `[Obsolete]` with
`[JsonIgnore]` rather than removed, since it is public API and could never have
been non-null anyway.

Every other member of the response was checked against our models and matches:
`project` → `ProjectInfo`, `tasks` → `TaskInfo`, `collaborators` →
`Collaborator`, `collaborator_states` → `CollaboratorState`.

### Tests

`GetDataAsync` had no test at all, which is how this shipped in the first place.
Now covered twice:

- a protocol test pinning the URI and the `tasks` property name — carries the
  `unit` trait, so CI gates on it. Confirmed it fails when the binding is
  reverted to `items`, so it is not a vacuous test.
- an integration test that creates a project with a task and reads it back, to
  catch the endpoint changing shape. Worth having because this route is not in
  the published OpenAPI spec, so the spec cannot warn us.

Both pass against the live API.